### PR TITLE
Add -P option to print filename when image is loaded

### DIFF
--- a/main.c
+++ b/main.c
@@ -319,6 +319,9 @@ void load_image(int new)
 	open_info();
 	arl_setup(&arl, files[fileidx].path);
 
+	if (options->print)
+		printf("%s\n", files[fileidx].name);
+
 	if (img.multi.cnt > 0 && img.multi.animate)
 		set_timeout(animate, img.multi.frames[img.multi.sel].delay, true);
 	else

--- a/options.c
+++ b/options.c
@@ -30,7 +30,7 @@ const opt_t *options = (const opt_t*) &_options;
 
 void print_usage(void)
 {
-	printf("usage: sxiv [-abcfhiopqrtvZ] [-A FRAMERATE] [-e WID] [-G GAMMA] "
+	printf("usage: sxiv [-abcfhiopPqrtvZ] [-A FRAMERATE] [-e WID] [-G GAMMA] "
 	       "[-g GEOMETRY] [-N NAME] [-n NUM] [-S DELAY] [-s MODE] [-z ZOOM] "
 	       "FILES...\n");
 }
@@ -71,8 +71,9 @@ void parse_options(int argc, char **argv)
 	_options.thumb_mode = false;
 	_options.clean_cache = false;
 	_options.private_mode = false;
+	_options.print = false;
 
-	while ((opt = getopt(argc, argv, "A:abce:fG:g:hin:N:opqrS:s:tvZz:")) != -1) {
+	while ((opt = getopt(argc, argv, "A:abce:fG:g:hin:N:opPqrS:s:tvZz:")) != -1) {
 		switch (opt) {
 			case '?':
 				print_usage();
@@ -130,6 +131,9 @@ void parse_options(int argc, char **argv)
 				break;
 			case 'p':
 				_options.private_mode = true;
+				break;
+			case 'P':
+				_options.print = true;
 				break;
 			case 'q':
 				_options.quiet = true;

--- a/sxiv.1
+++ b/sxiv.1
@@ -3,7 +3,7 @@
 sxiv \- Simple X Image Viewer
 .SH SYNOPSIS
 .B sxiv
-.RB [ \-abcfhiopqrtvZ ]
+.RB [ \-abcfhiopPqrtvZ ]
 .RB [ \-A
 .IR FRAMERATE ]
 .RB [ \-e
@@ -27,7 +27,7 @@ sxiv \- Simple X Image Viewer
 sxiv is a simple image viewer for X.
 .P
 It has two modes of operation: image and thumbnail mode. The default is image
-mode, in which only the current image is shown. In thumbnail mode a grid of 
+mode, in which only the current image is shown. In thumbnail mode a grid of
 small previews is displayed, making it easy to choose an image to open.
 .P
 Please note, that the fullscreen mode requires an EWMH/NetWM compliant window
@@ -82,6 +82,9 @@ sxiv can be used as a visual filter/pipe.
 .B \-p
 Enable private mode, in which sxiv does not write any cache or temporary files.
 .TP
+.B \-P
+Print the name of the current file to standard output when a new image is loaded.
+.TP
 .B \-q
 Be quiet, disable warnings to standard error stream.
 .TP
@@ -96,7 +99,7 @@ seconds.
 may be a floating point number.
 .TP
 .BI "\-s " MODE
-Set scale mode according to MODE character. Supported modes are: [d]own, 
+Set scale mode according to MODE character. Supported modes are: [d]own,
 [f]it (default), [w]idth, [h]eight.
 .TP
 .B \-t

--- a/sxiv.h
+++ b/sxiv.h
@@ -285,6 +285,7 @@ struct opt {
 	bool thumb_mode;
 	bool clean_cache;
 	bool private_mode;
+	bool print;
 };
 
 extern const opt_t *options;


### PR DESCRIPTION
This PR adds a new command line option `-P` that, when enabled, prints out the filename of the displayed image when the image is loaded.

## Changes

1. Added a new `print` flag to the `opt_t` struct in `sxiv.h`
2. Updated the option parsing in `options.c`:
   - Initialized the `print` flag to `false`
   - Added the `-P` option to the `getopt` string
   - Added a case for the `-P` option to set the `print` flag to `true`
   - Updated the usage message to include the new option
3. Modified the `load_image` function in `main.c` to print the filename when an image is loaded if the print flag is enabled
4. Updated the man page (`sxiv.1`) to include the new `-P` option and its description

## Testing

To test this feature, compile the program and run it with the `-P` option:

```
sxiv -P image.jpg
```

When the image is loaded, the filename will be printed to standard output. If you navigate to other images, their filenames will also be printed when they are loaded.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author